### PR TITLE
fix #109: Ellipsis will appear when the text is too long

### DIFF
--- a/js/utility.js
+++ b/js/utility.js
@@ -73,6 +73,7 @@ function getWrapText(text) {
             width: 120,
             height: 70,
         },
+        {},
         { ellipsis: true }
     )
 }

--- a/js/vendor/joint.js
+++ b/js/vendor/joint.js
@@ -8322,6 +8322,9 @@ var joint = {
 
                         // remove overflowing lines
                         lines.splice(Math.floor(height / lineHeight));
+                        if (opt.ellipsis) {
+                            lines[lines.length-1] = lines[lines.length-1].slice(0,-3)+'...'
+                        }
 
                         break;
                     }


### PR DESCRIPTION
**To test:** 
1. Create a comment block
2. Type some text more than the box could contain.
You will see the ellipsis at the end.